### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = path.abspath(path.dirname(__file__))
 setup(
     name='pylint-translations-rule',
 
-    version='0.0.3',
+    version='0.0.4',
 
     url='https://github.com/pypa/sampleproject',
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     packages=find_packages(),
 
     install_requires=[
-        'astroid==1.0.1',
-        'pylint==1.1.0',
+        'astroid==1.4.9',
+        'pylint==1.6.5',
         'pytest==3.0.7',
         'six',
     ],


### PR DESCRIPTION
Fix version conflicts

```
pylint-translations-rule 0.0.3 has requirement astroid==1.0.1, but you'll have astroid 1.4.9 which is incompatible.
pylint-translations-rule 0.0.3 has requirement pylint==1.1.0, but you'll have pylint 1.6.5 which is incompatible.
```